### PR TITLE
Bump Go to fix GO-2025-3420

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/freelensapp/freelens-k8s-proxy
 
-go 1.23.1
-
-toolchain go1.23.5
+go 1.23.5
 
 require (
 	k8s.io/cli-runtime v0.32.1


### PR DESCRIPTION
See https://github.com/freelensapp/freelens-k8s-proxy/security/code-scanning/7