### PR TITLE
Support SOCKS5 proxy for upgrade requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/freelensapp/freelens-k8s-proxy
 go 1.26.4
 
 require (
+	golang.org/x/net v0.56.0
+	k8s.io/apimachinery v0.36.2
 	k8s.io/cli-runtime v0.36.2
 	k8s.io/client-go v0.36.2
 	k8s.io/klog/v2 v2.140.0
@@ -51,7 +53,6 @@ require (
 	github.com/xlab/treeprint v1.2.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
@@ -62,7 +63,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/api v0.36.2 // indirect
-	k8s.io/apimachinery v0.36.2 // indirect
 	k8s.io/kube-openapi v0.0.0-20260603220949-865597e52e25 // indirect
 	k8s.io/streaming v0.36.2 // indirect
 	k8s.io/utils v0.0.0-20260507154919-ff6756f316d2 // indirect

--- a/upgrade_proxy.go
+++ b/upgrade_proxy.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	xproxy "golang.org/x/net/proxy"
 	apimachineryproxy "k8s.io/apimachinery/pkg/util/proxy"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/transport"
@@ -114,7 +115,12 @@ func (h *upgradePipeHandler) dialUpstream(ctx context.Context, req *http.Request
 
 	var rawConn net.Conn
 	if proxyURL != nil {
-		rawConn, err = dialThroughProxy(ctx, dialer, proxyURL, addr)
+		switch proxyURL.Scheme {
+		case "socks5", "socks5h":
+			rawConn, err = dialThroughSOCKS5(ctx, dialer, proxyURL, addr)
+		default:
+			rawConn, err = dialThroughProxy(ctx, dialer, proxyURL, addr)
+		}
 	} else {
 		rawConn, err = dialer.DialContext(ctx, "tcp", addr)
 	}
@@ -136,6 +142,30 @@ func (h *upgradePipeHandler) dialUpstream(ctx context.Context, req *http.Request
 		return nil, err
 	}
 	return tlsConn, nil
+}
+
+// dialThroughSOCKS5 opens a connection to the upstream through a SOCKS5
+// proxy. The target hostname is sent to the proxy for remote resolution,
+// so upstreams resolvable only from the proxy side (e.g. ssh -D bastions)
+// work.
+func dialThroughSOCKS5(ctx context.Context, dialer *net.Dialer, proxyURL *url.URL, targetAddr string) (net.Conn, error) {
+	u := *proxyURL
+	if u.Port() == "" {
+		u.Host = net.JoinHostPort(u.Hostname(), "1080")
+	}
+	socksDialer, err := xproxy.FromURL(&u, dialer)
+	if err != nil {
+		return nil, fmt.Errorf("socks5 proxy %s: %w", u.Host, err)
+	}
+	contextDialer, ok := socksDialer.(xproxy.ContextDialer)
+	if !ok {
+		return nil, fmt.Errorf("socks5 proxy %s: dialer does not support context", u.Host)
+	}
+	conn, err := contextDialer.DialContext(ctx, "tcp", targetAddr)
+	if err != nil {
+		return nil, fmt.Errorf("dial %s via socks5 proxy %s: %w", targetAddr, u.Host, err)
+	}
+	return conn, nil
 }
 
 // dialThroughProxy opens a TCP connection to the HTTP proxy and issues a


### PR DESCRIPTION
Route exec/attach/port-forward upgrade dials through a SOCKS5 proxy when the kubeconfig `proxy-url` (or `ALL_PROXY` fallback) uses a `socks5`/`socks5h` scheme. The target hostname is resolved on the proxy side, so API servers reachable only via an `ssh -D` bastion work.

Closes #166. Relates to freelensapp/freelens#766.