### PR TITLE
Group goreleaser Renovate updates into a single PR

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -10,6 +10,18 @@
   "postUpdateOptions": [
     "gomodTidy"
   ],
+  "packageRules": [
+    // goreleaser is tracked both in mise.toml (depName "goreleaser") and in
+    // the workflow files (depName "goreleaser/goreleaser"); group them so a
+    // version bump lands in a single PR instead of two
+    {
+      "matchDepNames": [
+        "goreleaser",
+        "goreleaser/goreleaser"
+      ],
+      "groupName": "goreleaser"
+    }
+  ],
   "constraints": {
     // allow minor updates for go
     "go": ">= 1.23"


### PR DESCRIPTION
Groups the two Renovate-tracked goreleaser sources (`mise.toml` and the workflow files) under a single `groupName` so a version bump lands in one PR instead of two.

Fixes #175

Generated with [Claude Code](https://claude.ai/code)