### PR TITLE
Report the vulnerabilities of the last release and scan every platform

### DIFF
--- a/.github/workflows/grype-scanner.yaml
+++ b/.github/workflows/grype-scanner.yaml
@@ -41,7 +41,7 @@ jobs:
 
       # yq comes from mise so that its version has a single source (mise.toml)
       # and the download is verified against mise.lock.
-      - name: Set up yq
+      - name: Set up mise
         uses: jdx/mise-action@v4
         with:
           version: 2026.7.13 # datasource=github-releases depName=jdx/mise
@@ -138,7 +138,7 @@ jobs:
 
       # yq comes from mise so that its version has a single source (mise.toml)
       # and the download is verified against mise.lock.
-      - name: Set up yq
+      - name: Set up mise
         uses: jdx/mise-action@v4
         with:
           version: 2026.7.13 # datasource=github-releases depName=jdx/mise

--- a/.github/workflows/grype-scanner.yaml
+++ b/.github/workflows/grype-scanner.yaml
@@ -39,14 +39,15 @@ jobs:
         with:
           go-version-file: go.mod
 
-      # yq comes from mise so that its version has a single source (mise.toml)
-      # and the download is verified against mise.lock.
+      # GoReleaser and yq come from mise so that their versions have a single
+      # source (mise.toml) and the downloads are verified against mise.lock.
       - name: Set up mise
         uses: jdx/mise-action@v4
         with:
           version: 2026.7.13 # datasource=github-releases depName=jdx/mise
-          install_args: yq
+          install_args: goreleaser yq
 
+      # Required by the sboms section of .goreleaser.yaml.
       - name: Install Syft
         uses: anchore/sbom-action/download-syft@v0
 
@@ -58,42 +59,90 @@ jobs:
           cache-db: true
 
       # What is published - the SBOM and the vulnerability report - describes
-      # the released binary, so the scan starts from one. A single Go binary
-      # has the same dependency set regardless of target OS/arch, and grype
-      # matches the stdlib on its recorded version rather than on GOOS, so
-      # building one target is enough - no per-arch matrix.
-      - name: Build binary
-        run: go build -trimpath -o freelens-k8s-proxy .
-        env:
-          CGO_ENABLED: "0"
+      # the released binaries, so the scan starts from them. A snapshot release
+      # produces all six with the SBOM configuration the real release uses, so
+      # the scan input is built exactly the way the shipped one is.
+      #
+      # All six are scanned, not one: the dependency set is not the same across
+      # targets. The Windows builds link 67 modules against 65 elsewhere -
+      # go-ansiterm and mousetrap are Windows-only - so a single-target scan
+      # has a permanent blind spot.
+      - name: Build the release artifacts and their SBOMs
+        run: goreleaser release --snapshot --clean --skip=publish
 
-      # The same syft invocation as the sboms section of .goreleaser.yaml, so
-      # that what is scanned here is what ships with the release.
-      - name: Create SBOM
-        run: syft freelens-k8s-proxy --output spdx-json=freelens-k8s-proxy.sbom.json
-
-      # Scanning the SBOM instead of the binary is not cosmetic: on the same
-      # go1.26.4 build `grype file:` reported 1 finding where the SBOM
-      # reported 3, silently dropping a module CVE and a stdlib advisory. The
-      # published SPDX and syft's own json give identical results, so the file
-      # users receive is the one that gets scanned. json is produced alongside
-      # sarif because post-scan-report needs fields sarif does not carry:
-      # component type, installed/fixed-in versions and risk score.
-      - name: Scan SBOM with Grype
+      # json is produced alongside sarif because post-scan-report needs fields
+      # sarif does not carry: component type, installed/fixed-in versions and
+      # risk score. Scanning the SBOM rather than the binary is not cosmetic:
+      # on the same go1.26.4 build `grype file:` reported 1 finding where the
+      # SBOM reported 3, silently dropping a module CVE and a stdlib advisory.
+      - name: Scan the SBOMs with Grype
         run: |
           set -eo pipefail
-          "${{ steps.grype.outputs.cmd }}" sbom:freelens-k8s-proxy.sbom.json -o sarif=grype.sarif -o json=grype.json
+          mkdir -p sarifs jsons
+          for sbom in dist/*.sbom.json; do
+            platform=$(basename "$sbom" .sbom.json | sed 's/^${{ github.event.repository.name }}-//; s/\.exe$//')
+            echo "::group::grype $sbom"
+            "${{ steps.grype.outputs.cmd }}" "sbom:$sbom" -o sarif="sarifs/$platform.sarif" -o json="jsons/$platform.json"
+            echo "::endgroup::"
+            yq -pj -oj '.matches |= map(.platforms = ["'"$platform"'"])' "jsons/$platform.json" > "jsons/$platform.tagged.json"
+          done
 
-      # Grype points the findings at the artifact recorded in the SBOM, a path
-      # that does not exist in the repository, so code scanning cannot map an
-      # alert to a source file. go.mod is where both stdlib and module
+      # Code scanning accepts one run per category, so the six are merged as in
+      # freelensapp/freelens: union the rules by id and concatenate the
+      # results, dropping the duplicates a finding shared by every platform
+      # produces. Grype points them at the artifact recorded in the SBOM, a
+      # path that does not exist in the repository, so code scanning cannot map
+      # an alert to a source file; go.mod is where both stdlib and module
       # findings are actually fixed.
-      - name: Repoint SARIF findings at go.mod
+      - name: Merge the SARIF reports
         run: |
           set -eo pipefail
-          yq -pj -oj '(.runs[].results[].locations[].physicalLocation.artifactLocation.uri) = "go.mod"' \
-            grype.sarif > grype.sarif.tmp
-          mv grype.sarif.tmp grype.sarif
+          yq ea -pj -oj -I0 '[.]' sarifs/*.sarif |
+            yq -pj -oj '
+                . as $x
+                | {
+                    "$schema": $x[0]["$schema"],
+                    "version": $x[0].version,
+                    "runs": [
+                      {
+                        "tool": {
+                          "driver": (
+                            $x[0].runs[0].tool.driver
+                            | .rules = ([$x[].runs[0].tool.driver.rules[]] | unique_by(.id))
+                          )
+                        },
+                        "results": (
+                          [$x[].runs[0].results[]]
+                          | map(.locations[].physicalLocation.artifactLocation.uri = "go.mod")
+                          | unique
+                        )
+                      }
+                    ]
+                  }
+              ' > grype.sarif
+
+      # Same merge for the JSON report, keeping which platforms a finding came
+      # from so a Windows-only module is not read as affecting every artifact.
+      - name: Merge the vulnerability reports
+        run: |
+          set -eo pipefail
+          # The full platform list goes in too: a finding present on every one
+          # of them renders as "all" in the report, and that cannot be derived
+          # from the findings alone.
+          PLATFORMS=$(basename -a -s .tagged.json jsons/*.tagged.json | paste -sd,)
+          export PLATFORMS
+          yq ea -pj -oj -I0 '[.]' jsons/*.tagged.json |
+            yq -pj -oj '
+                . as $x
+                | {
+                    "platforms": (strenv(PLATFORMS) | split(",")),
+                    "matches": (
+                      [$x[].matches[]]
+                      | group_by(.vulnerability.id + "@" + .artifact.name + "@" + .artifact.version)
+                      | map(.[0] * {"platforms": (map(.platforms[0]) | unique)})
+                    )
+                  }
+              ' > grype.json
 
       - name: Upload Grype SARIF to code scanning
         uses: github/codeql-action/upload-sarif@v4
@@ -169,6 +218,7 @@ jobs:
                   "installed": .artifact.version,
                   "fixed": ((.vulnerability.fix.versions // []) | join(", ")),
                   "advisory": ("[" + .vulnerability.id + "](" + (.vulnerability.dataSource // "") + ")"),
+                  "platforms": ((.platforms // []) | sort | join(", ")),
                   "rank": ($rank[.vulnerability.severity] // 9),
                   "negrisk": (0 - (.vulnerability.risk // 0))
                 }
@@ -177,19 +227,26 @@ jobs:
             | map(del(.rank) | del(.negrisk))
           ' grype.json > rows.json
           count=$(yq -pj -oj 'length' rows.json)
+          # Collapsing the full platform list to "all" is done here rather than
+          # in yq: yq has no if/then/else, and `select(false) | "all"` still
+          # emits "all", so the conditional has to live outside the filter.
+          every=$(yq -pj -oy '(.platforms // []) | sort | join(", ")' grype.json)
           {
-            echo "Vulnerabilities in the binary built from [\`${GITHUB_SHA:0:12}\`]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/commit/$GITHUB_SHA), scanned through the same SBOM that ships with a release. Updated $(date -u +'%Y-%m-%d %H:%M UTC') by [this run]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)."
+            echo "Vulnerabilities in the binaries built from [\`${GITHUB_SHA:0:12}\`]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/commit/$GITHUB_SHA), scanned through the same SBOMs that ship with a release. Updated $(date -u +'%Y-%m-%d %H:%M UTC') by [this run]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)."
             echo
             if [[ "$count" -eq 0 ]]; then
               echo "No vulnerabilities found."
             else
-              echo "| Severity | Risk | Package | Type | Installed | Fixed In | Advisory |"
-              echo "| --- | --- | --- | --- | --- | --- | --- |"
+              echo "| Severity | Risk | Package | Type | Installed | Fixed In | Advisory | Platforms |"
+              echo "| --- | --- | --- | --- | --- | --- | --- | --- |"
               # LC_ALL=C: printf "%.1f" must use a period regardless of the
               # runner's locale, or it silently truncates "6.6" to "6" (parsed
               # up to the first non-digit) and re-renders it as "6,0".
               yq -pj -ot rows.json | tail -n +2 |
-                LC_ALL=C awk -F'\t' '{printf "| %s | %.1f | %s | %s | %s | %s | %s |\n", $1, $2, $3, $4, $5, $6, $7}'
+                LC_ALL=C awk -F'\t' -v every="$every" '{
+                  if ($8 == every) $8 = "all"
+                  printf "| %s | %.1f | %s | %s | %s | %s | %s | %s |\n", $1, $2, $3, $4, $5, $6, $7, $8
+                }'
             fi
           } > body.md
           echo "vulnerabilities: $count"

--- a/.github/workflows/grype-scanner.yaml
+++ b/.github/workflows/grype-scanner.yaml
@@ -1,10 +1,12 @@
 name: Grype Scanner
 
+# No pull_request trigger: the scan is not a required status check, so on a PR
+# it gates nothing, while the snapshot release it builds is the slowest job in
+# the repository. A vulnerability is a property of the published artifacts and
+# of the advisory feed, not of the change under review - main and the nightly
+# schedule are where it has to be caught.
 on:
   push:
-    branches:
-      - main
-  pull_request:
     branches:
       - main
   schedule:
@@ -151,7 +153,7 @@ jobs:
           category: grype
 
       - name: Upload vulnerability report
-        if: github.ref_name == 'main' && github.event_name != 'pull_request'
+        if: github.ref_name == 'main'
         uses: actions/upload-artifact@v7
         with:
           name: "${{ github.event.repository.name }}-grype.json"
@@ -162,9 +164,10 @@ jobs:
 
     # Turns the Grype JSON report from the scan job into a markdown table and
     # replaces the tracking discussion's body with it, so the discussion
-    # always reflects the latest main-branch scan. Runs for the real branch
-    # build (push/dispatch on main) only, never for PRs.
-    if: github.ref_name == 'main' && github.event_name != 'pull_request'
+    # always reflects the latest main-branch scan. A workflow_dispatch on
+    # another branch would report that branch as if it were main, hence the
+    # guard.
+    if: github.ref_name == 'main'
 
     needs:
       - scan

--- a/.github/workflows/main-scan.yaml
+++ b/.github/workflows/main-scan.yaml
@@ -1,5 +1,9 @@
-name: Grype Scanner
+name: Main Scan
 
+# Scans what the main branch currently builds. Its counterpart, Release Scan,
+# scans what the last release actually shipped - same report, different
+# subject, hence two workflows rather than one with a branch in it.
+#
 # No pull_request trigger: the scan is not a required status check, so on a PR
 # it gates nothing, while the snapshot release it builds is the slowest job in
 # the repository. A vulnerability is a property of the published artifacts and
@@ -18,7 +22,7 @@ permissions:
 
 jobs:
   scan:
-    name: Grype scan
+    name: Scan the main branch
 
     runs-on: ubuntu-24.04-arm
 
@@ -72,7 +76,7 @@ jobs:
       - name: Build the release artifacts and their SBOMs
         run: goreleaser release --snapshot --clean --skip=publish
 
-      # json is produced alongside sarif because post-scan-report needs fields
+      # json is produced alongside sarif because the report job needs fields
       # sarif does not carry: component type, installed/fixed-in versions and
       # risk score. Scanning the SBOM rather than the binary is not cosmetic:
       # on the same go1.26.4 build `grype file:` reported 1 finding where the
@@ -159,8 +163,8 @@ jobs:
           name: "${{ github.event.repository.name }}-grype.json"
           path: grype.json
 
-  post-scan-report:
-    name: post scan report to discussion
+  report:
+    name: Report to discussion
 
     # Turns the Grype JSON report from the scan job into a markdown table and
     # replaces the tracking discussion's body with it, so the discussion

--- a/.github/workflows/release-scan.yaml
+++ b/.github/workflows/release-scan.yaml
@@ -1,0 +1,204 @@
+name: Release Scan
+
+on:
+  schedule:
+    - cron: 38 21 * * *
+  workflow_dispatch: {}
+  # Refreshes the report as soon as a release is published. workflow_run rather
+  # than the release event, because GoReleaser uploads the assets after
+  # creating the release - waiting for the whole run is what guarantees the
+  # SBOMs are there.
+  workflow_run:
+    workflows:
+      - Release
+    types:
+      - completed
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Scan the last release
+
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+
+    runs-on: ubuntu-24.04-arm
+
+    permissions:
+      contents: read
+      discussions: write
+
+    env:
+      # Renovate keeps this version up to date via the inline datasource hint
+      # below (see .renovaterc.json5 customManagers).
+      GRYPE_VERSION: v0.116.0 # datasource=github-releases depName=anchore/grype
+      DISCUSSION_NUMBER: 183
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      # yq comes from mise so that its version has a single source (mise.toml)
+      # and the download is verified against mise.lock.
+      - name: Set up mise
+        uses: jdx/mise-action@v4
+        with:
+          version: 2026.7.13 # datasource=github-releases depName=jdx/mise
+          install_args: yq
+
+      - name: Install Grype
+        id: grype
+        uses: anchore/scan-action/download-grype@v7
+        with:
+          grype-version: ${{ env.GRYPE_VERSION }}
+          cache-db: true
+
+      # The SBOMs published with the release are the manifest of what users
+      # actually downloaded, so they are the input here - this job never builds
+      # anything and never looks at the working tree.
+      - name: Download the SBOMs of the last release
+        id: release
+        run: |
+          set -eo pipefail
+          tag=$(gh release view --json tagName --jq .tagName)
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "url=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/tag/$tag" >> "$GITHUB_OUTPUT"
+          mkdir -p sboms
+          gh release download "$tag" --pattern '*.sbom.json' --dir sboms || true
+          count=$(find sboms -name '*.sbom.json' | wc -l)
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          echo "$tag has $count published SBOM(s)"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Releases made before SBOM publishing was added have no SBOM to scan.
+      # Say so in the discussion instead of failing every night - the next
+      # release fixes it on its own.
+      - name: Report a release without SBOMs
+        if: steps.release.outputs.count == '0'
+        run: |
+          set -eo pipefail
+          {
+            echo "The last release, [\`${{ steps.release.outputs.tag }}\`](${{ steps.release.outputs.url }}), ships no SBOM: it predates SBOM publishing."
+            echo
+            echo "This report starts with the first release that publishes one. Updated $(date -u +'%Y-%m-%d %H:%M UTC') by [this run]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)."
+          } > body.md
+
+      # Every published SBOM is scanned, not just one: the Windows builds link
+      # two modules the other platforms do not (go-ansiterm and mousetrap), so
+      # a single-platform scan has a permanent blind spot.
+      - name: Scan the SBOMs with Grype
+        if: steps.release.outputs.count != '0'
+        run: |
+          set -eo pipefail
+          mkdir -p jsons
+          for sbom in sboms/*.sbom.json; do
+            platform=$(basename "$sbom" .sbom.json | sed 's/^${{ github.event.repository.name }}-//; s/\.exe$//')
+            echo "::group::grype $sbom"
+            "${{ steps.grype.outputs.cmd }}" "sbom:$sbom" -o json="jsons/$platform.json"
+            echo "::endgroup::"
+            yq -pj -oj '.matches |= map(.platforms = ["'"$platform"'"])' "jsons/$platform.json" > "jsons/$platform.tagged.json"
+          done
+
+      # Merge as in freelensapp/freelens: slurp the per-platform reports and
+      # collapse a finding that repeats across platforms into one row. The
+      # platforms it came from are kept so a Windows-only module is not read as
+      # affecting every artifact.
+      - name: Merge the per-platform reports
+        if: steps.release.outputs.count != '0'
+        run: |
+          set -eo pipefail
+          # The full platform list goes in too: a finding present on every one
+          # of them renders as "all" in the report, and that cannot be derived
+          # from the findings alone.
+          PLATFORMS=$(basename -a -s .tagged.json jsons/*.tagged.json | paste -sd,)
+          export PLATFORMS
+          yq ea -pj -oj -I0 '[.]' jsons/*.tagged.json |
+            yq -pj -oj '
+                . as $x
+                | {
+                    "platforms": (strenv(PLATFORMS) | split(",")),
+                    "matches": (
+                      [$x[].matches[]]
+                      | group_by(.vulnerability.id + "@" + .artifact.name + "@" + .artifact.version)
+                      | map(.[0] * {"platforms": (map(.platforms[0]) | unique)})
+                    )
+                  }
+              ' > grype.json
+
+      - name: Build the vulnerability table
+        if: steps.release.outputs.count != '0'
+        run: |
+          set -eo pipefail
+          # Same shape as the main-branch report in grype-scanner.yaml, plus a
+          # Platforms column. negrisk is a sort-only helper: yq has no unary
+          # minus, so descending-by-risk needs the value pre-negated.
+          total=$(yq -pj -oj '.platforms | length' grype.json)
+          yq -pj -oj '
+            ({"Critical":0,"High":1,"Medium":2,"Low":3,"Negligible":4,"Unknown":5}) as $rank
+            | (.matches // [])
+            | map(
+                {
+                  "severity": .vulnerability.severity,
+                  "risk": (.vulnerability.risk // 0),
+                  "package": .artifact.name,
+                  "type": .artifact.type,
+                  "installed": .artifact.version,
+                  "fixed": ((.vulnerability.fix.versions // []) | join(", ")),
+                  "advisory": ("[" + .vulnerability.id + "](" + (.vulnerability.dataSource // "") + ")"),
+                  "platforms": ((.platforms // []) | sort | join(", ")),
+                  "rank": ($rank[.vulnerability.severity] // 9),
+                  "negrisk": (0 - (.vulnerability.risk // 0))
+                }
+              )
+            | sort_by(.rank, .negrisk, .package)
+            | map(del(.rank) | del(.negrisk))
+          ' grype.json > rows.json
+          count=$(yq -pj -oj 'length' rows.json)
+          # Collapsing the full platform list to "all" is done here rather than
+          # in yq: yq has no if/then/else, and `select(false) | "all"` still
+          # emits "all", so the conditional has to live outside the filter.
+          every=$(yq -pj -oy '(.platforms // []) | sort | join(", ")' grype.json)
+          {
+            echo "Vulnerabilities in the published artifacts of [\`${{ steps.release.outputs.tag }}\`](${{ steps.release.outputs.url }}), scanned from the $total SBOMs shipped with the release. Updated $(date -u +'%Y-%m-%d %H:%M UTC') by [this run]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)."
+            echo
+            if [[ "$count" -eq 0 ]]; then
+              echo "No vulnerabilities found."
+            else
+              echo "| Severity | Risk | Package | Type | Installed | Fixed In | Advisory | Platforms |"
+              echo "| --- | --- | --- | --- | --- | --- | --- | --- |"
+              # LC_ALL=C: printf "%.1f" must use a period regardless of the
+              # runner's locale, or it silently truncates "6.6" to "6" (parsed
+              # up to the first non-digit) and re-renders it as "6,0".
+              yq -pj -ot rows.json | tail -n +2 |
+                LC_ALL=C awk -F'\t' -v every="$every" '{
+                  if ($8 == every) $8 = "all"
+                  printf "| %s | %.1f | %s | %s | %s | %s | %s | %s |\n", $1, $2, $3, $4, $5, $6, $7, $8
+                }'
+            fi
+          } > body.md
+          echo "vulnerabilities: $count"
+
+      - name: Update discussion
+        run: |
+          set -eo pipefail
+          discussion_id=$(gh api graphql -f query='
+            query($owner:String!,$repo:String!,$num:Int!){
+              repository(owner:$owner,name:$repo){
+                discussion(number:$num){ id }
+              }
+            }' -f owner="${{ github.repository_owner }}" -f repo="${{ github.event.repository.name }}" -F num="$DISCUSSION_NUMBER" \
+            --jq '.data.repository.discussion.id')
+          if [[ -z "$discussion_id" || "$discussion_id" == "null" ]]; then
+            echo "Discussion #$DISCUSSION_NUMBER not found" >&2
+            exit 1
+          fi
+          gh api graphql -f query='
+            mutation($id:ID!,$body:String!){
+              updateDiscussion(input:{discussionId:$id, body:$body}){
+                discussion{ id }
+              }
+            }' -f id="$discussion_id" -F body=@body.md
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-scan.yaml
+++ b/.github/workflows/release-scan.yaml
@@ -8,6 +8,12 @@ on:
   # than the release event, because GoReleaser uploads the assets after
   # creating the release - waiting for the whole run is what guarantees the
   # SBOMs are there.
+  #
+  # Not workflow_call from release.yaml, which would put this job in the
+  # release run and read better: a job that calls a reusable workflow accepts
+  # none of continue-on-error, so a scan that fails - an advisory feed that is
+  # down, a rate limit - would mark an otherwise correct release as failed. A
+  # separate run keeps the release conclusion about the release.
   workflow_run:
     workflows:
       - Release

--- a/.github/workflows/release-scan.yaml
+++ b/.github/workflows/release-scan.yaml
@@ -1,5 +1,8 @@
 name: Release Scan
 
+# Scans what the last release actually shipped, from the SBOMs published with
+# it. Its counterpart, Main Scan, scans what the main branch currently builds.
+
 on:
   schedule:
     - cron: 38 21 * * *
@@ -137,7 +140,7 @@ jobs:
         if: steps.release.outputs.count != '0'
         run: |
           set -eo pipefail
-          # Same shape as the main-branch report in grype-scanner.yaml, plus a
+          # Same shape as the main-branch report in main-scan.yaml, plus a
           # Platforms column. negrisk is a sort-only helper: yq has no unary
           # minus, so descending-by-risk needs the value pre-negated.
           total=$(yq -pj -oj '.platforms | length' grype.json)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,7 @@ jobs:
 
       # GoReleaser and yq come from mise so that their versions have a single
       # source (mise.toml) and the downloads are verified against mise.lock.
-      - name: Set up GoReleaser and yq
+      - name: Set up mise
         uses: jdx/mise-action@v4
         with:
           version: 2026.7.13 # datasource=github-releases depName=jdx/mise

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,7 +46,7 @@ jobs:
 
       # GoReleaser and yq come from mise so that their versions have a single
       # source (mise.toml) and the downloads are verified against mise.lock.
-      - name: Set up GoReleaser and yq
+      - name: Set up mise
         uses: jdx/mise-action@v4
         with:
           version: 2026.7.13 # datasource=github-releases depName=jdx/mise


### PR DESCRIPTION
Adds the release report asked for in discussion #183, and fixes a blind spot the
main-branch scan had since #182.

## The dependency set is not the same across targets

Measured on a snapshot release of this repository:

| target | modules |
| --- | --- |
| linux, darwin (4 targets) | 65 |
| windows (2 targets) | 67 |

`github.com/Azure/go-ansiterm` and `github.com/inconshreveable/mousetrap` are
linked only into the Windows binaries. Scanning one target - what #182 did, with
a comment asserting a per-arch matrix was unnecessary - left those two
permanently unscanned. Both workflows now scan every SBOM.

## Release Scan, new workflow

Reports to #183 from the SBOMs published with the last release. It builds
nothing and never reads the working tree: the input is the file users
downloaded, pulled from the release assets.

Triggers are nightly, manual, and `workflow_run` on a completed Release.
`workflow_run` rather than the `release` event because GoReleaser uploads the
assets after creating the release, so only the finished run guarantees the SBOMs
are there.

`v1.8.2` predates SBOM publishing, so there is nothing to scan yet - verified
against the real release, `gh release download --pattern '*.sbom.json'` exits 1
with "no assets match the file pattern". The workflow says so in the discussion
instead of failing every night, and the first release that publishes an SBOM
resolves it on its own.

## Grype Scanner, main branch

Now builds the artifacts with a snapshot release, so the scan input comes from
the same SBOM configuration the real release uses, and scans all six. The
per-platform SARIFs are merged into the single run code scanning accepts per
category; the JSON reports are merged as in freelensapp/freelens, keeping which
platforms each finding came from.

Both reports gain a **Platforms** column, so a Windows-only finding is not read
as affecting every artifact:

| Severity | Risk | Package | ... | Platforms |
| --- | --- | --- | --- | --- |
| High | 6.6 | golang.org/x/text | ... | all |
| Medium | 3.2 | github.com/Azure/go-ansiterm | ... | windows-amd64, windows-arm64 |

## Verified locally

- The scan and merge steps run against the six real SBOMs: six SARIFs collapse
  to one run with a valid schema, and the merged JSON carries the full platform
  list
- Both table steps extracted from the workflow YAML and rendered against a
  dataset with a shared and a Windows-only finding, plus the empty case
- The no-SBOM path checked against the actual `v1.8.2` release

One yq limitation worth recording: it has no `if/then/else`, and
`select(false) | "all"` still emits `"all"`, so the conditional that collapses a
full platform list to "all" lives in awk rather than in the filter.

Generated with [Claude Code](https://claude.com/claude-code)
